### PR TITLE
Supprime les différents types de membres

### DIFF
--- a/_pages/statuts.md
+++ b/_pages/statuts.md
@@ -25,20 +25,11 @@ Le siège social est fixé à Paris, dans le 12ème arrondissement. Il pourra ê
 
 La durée de l’association est illimitée.
 
-## Article 5 : Membres
-
-L’association se compose de membres actifs, de membres honoraires et de membres bienfaiteurs.
-Les membres actifs s’engagent à régler une cotisation annuelle dont le montant et les modalités, qui peuvent varier en fonction de la qualité desdits membres, sont précisés par le Règlement Intérieur de l’association.
-
-Les membres honoraires, dispensés de cotisation, sont désignés par un vote du Bureau.
-
-Les membres bienfaiteurs sont des personnes physiques ou morales s’acquittant d’une cotisation dont le montant est fixé individuellement par vote du Bureau et qui ne disposent pas d’un droit de vote aux assemblées générales.
-
-## Article 6 : Adhésion
+## Article 5 : Adhésion
 
 Est admise au sein de l’association toute personne qui s’est régulièrement acquittée de sa cotisation selon la procédure alors définie par le Règlement Intérieur.
 
-## Article 7 : Cessation
+## Article 6 : Cessation
 
 La qualité de membre se perd par :
 
@@ -46,7 +37,7 @@ a) la démission ;
 b) le décès ;
 c) la radiation prononcée par le Bureau pour un non-paiement de la cotisation ou pour motif grave, l’intéressé ayant été invité, par courrier simple (y compris par voie électronique) pour les motifs de non-paiement, par lettre recommandée pour les autres motifs, à fournir des explications devant le Bureau.
 
-## Article 8 : Ressources
+## Article 7 : Ressources
 
 Les ressources de l’association comprennent :
 
@@ -54,7 +45,7 @@ Les ressources de l’association comprennent :
 - les subventions des acteurs publics ;
 - toutes recettes autorisées par la Loi.
 
-## Article 9 : Bureau
+## Article 8 : Bureau
 
 L’association est dirigée par un Bureau de 5 membres, élu pour 2 années par l’Assemblée générale. Les membres du Bureau organisent leur travail selon les principes agiles.
 
@@ -67,8 +58,8 @@ Les membres sont rééligibles.
 En cas de cessation d’activité d’un des membres du Bureau, un·e autre membre de l’association peut être présenté·e à la plus prochaine assemblée générale.
 Le mandat des membres remplaçants prend fin en même temps que celui des autres membres du Bureau.
 
+## Article 9 : Assemblée générale (AG)
 
-## Article 10 : Assemblée générale (AG)
 L’Assemblée générale comprend tous les membres de l’association.
 
 Deux semaines au moins avant la date fixée, les membres de l’association sont convoqués par le Bureau. L’ordre du jour est indiqué sur les convocations.
@@ -82,25 +73,25 @@ Les décisions en Assemblée générale sont prises à la majorité des membres 
 
 Un compte-rendu est signé par le Bureau et rendu accessible aux membres sur le site internet de l'association après chaque Assemblée générale.
 
-## Article 11 : Assemblée générale ordinaire (AGO)
+## Article 10 : Assemblée générale ordinaire (AGO)
 
 L’Assemblée générale ordinaire se réunit une fois par an.
 
 La période habituelle est définie dans le Règlement intérieur.
 
-## Article 12 : Assemblée générale extraordinaire (AGX)
+## Article 11 : Assemblée générale extraordinaire (AGX)
 
 Le Bureau peut convoquer une Assemblée générale extraordinaire en plus de l'AGO.
 
 Le Bureau doit convoquer une AGX sur demande de la majorité des membres.
 
-## Article 13 : Règlement intérieur
+## Article 12 : Règlement intérieur
 
 Un Règlement intérieur est établi par le Bureau. Il fixe les divers points non prévus par les statuts, notamment ceux qui ont trait à l’administration interne de l’association. Tout point qui contredirait les statuts est considéré comme nul.
 
 Ce Règlement intérieur peut être modifié par vote majoritaire simple du Bureau. Les changements sont ratifiés à la prochaine Assemblée générale.
 
-## Article 14 : Dissolution
+## Article 13 : Dissolution
 
 
 


### PR DESCRIPTION
Ces types ajoutent de la complexité. Pour autant, à ma connaissance, aucun des types autres que membre standard n'a jamais été utilisé de toute la vie de l'association.

@Morendil as-tu du contexte supplémentaire à partager sur l'intention et l'usage ? 🙂 