### PR TITLE
Passe l'élection du Bureau au jugement majoritaire

### DIFF
--- a/_pages/statuts.md
+++ b/_pages/statuts.md
@@ -58,13 +58,13 @@ Les ressources de l’association comprennent :
 
 L’association est dirigée par un Bureau de 5 membres, élu pour 2 années par l’Assemblée générale. Les membres du Bureau organisent leur travail selon les principes agiles.
 
-L’élection se fait par la candidature de listes de 5 membres, décrites par une profession de foi lue lors de l'Assemblée générale. Ces listes sont soumises au vote des adhérent·e·s, qui désignent celle élue par vote majoritaire simple.
+L’élection se fait par la candidature de listes de 5 membres, décrites par une profession de foi lue lors de l'Assemblée générale. Ces listes sont soumises au vote des adhérent·e·s, qui désignent celle élue par jugement majoritaire.
 
-Le Bureau désigne par vote majoritaire simple l’un de ses membres comme responsable juridique. Cette nomination est ajoutée au compte-rendu de l'Assemblée générale.
+Le Bureau désigne par scrutin majoritaire simple l’un de ses membres comme responsable juridique. Cette nomination est ajoutée au compte-rendu de l'Assemblée générale.
 
 Les membres sont rééligibles.
 
-En cas de cessation d’activité d’un des membres du Bureau, un·e autre membre de l’association peut être présenté·e à la plus prochaine assemblée générale.
+En cas de cessation d’activité d’un des membres du Bureau, un·e autre membre de l’association peut être présenté·e à la plus prochaine assemblée générale. Si ce membre n’est pas ratifié au scrutin majoritaire simple, des candidatures individuelles peuvent être également présentées par d’autres membres. Le membre est alors élu·e par jugement majoritaire.
 Le mandat des membres remplaçants prend fin en même temps que celui des autres membres du Bureau.
 
 

--- a/_pages/statuts.md
+++ b/_pages/statuts.md
@@ -64,7 +64,7 @@ Le Bureau désigne par scrutin majoritaire simple l’un de ses membres comme re
 
 Les membres sont rééligibles.
 
-En cas de cessation d’activité d’un des membres du Bureau, un·e autre membre de l’association peut être présenté·e à la plus prochaine assemblée générale. Si ce membre n’est pas ratifié au scrutin majoritaire simple, des candidatures individuelles peuvent être également présentées par d’autres membres. Le membre est alors élu·e par jugement majoritaire.
+En cas de cessation d’activité d’un des membres du Bureau, un·e autre membre de l’association peut être présenté·e à la plus prochaine assemblée générale. Si ce membre n’est pas ratifié au scrutin majoritaire simple, des candidatures individuelles peuvent être également présentées par d’autres membres. La ou le membre est alors élu·e par jugement majoritaire.
 Le mandat des membres remplaçants prend fin en même temps que celui des autres membres du Bureau.
 
 


### PR DESCRIPTION
Le « scrutin majoritaire » est le vote le plus habituel en France (on a une voix et on l'attribue à une liste / personne). Ce n'est pas pour autant le plus juste, ni le plus efficace des votes. Le [jugement majoritaire](https://www.lechoixcommun.fr/articles/Le_Jugement_Majoritaire.html) est bien meilleur. Je propose que les membres du Bureau soient élu‧e‧s au jugement majoritaire.

Les modalités pratiques sont bien détaillées ici : https://www.jugementmajoritaire2017.com 🙂 

![](https://s3.eu-west-2.amazonaws.com/www.jugementmajoritaire2017.com/images/bd/jm-MarjolaineLerayBD03.jpg)