### PR TITLE
met à jour l'image docker de circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-       - image: circleci/ruby:2.5.3-browsers  # use the browsers variant image to have Java preinstalled as it is a dependency of html5validator
+       - image: circleci/ruby:2.5.8-browsers  # use the browsers variant image to have Java preinstalled as it is a dependency of html5validator
 
     steps:
       - checkout


### PR DESCRIPTION
corrige le problème d'incompatibilité de version entre la version de ruby de CircleCI et celle de Github Pages, qui bloque le déploiement

`Your Ruby version is 2.5.3, but your Gemfile specified 2.5.8`
[Log CircleCI](https://app.circleci.com/pipelines/github/AgileFrance/AgileFrance.github.io/24/workflows/d5fe9317-26a1-4a25-83ec-633f0f915b3b/jobs/139/steps)
