### PR TITLE
Éclate la page d'accueil en deux

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,20 +22,11 @@
         <a href="/#initiatives-soutenues">
           Initiatives soutenues
         </a>
-        <a href="/#le-mot-de-lasso">
-          Le mot de l'asso
-        </a>
-        <a href="/#assemblées-générales">
-          Assemblées générales
-        </a>
-        <a href="/#bureaux">
-          Bureaux
-        </a>
-        <a href="/#documents">
-          Documents
+        <a href="/association">
+          Vie associative
         </a>
       </nav>
-      <a href="/#adhérer" class="btn">
+      <a href="/adhesion" class="btn">
         Adhérer
       </a>
     </header>

--- a/_pages/adhesion.html
+++ b/_pages/adhesion.html
@@ -3,5 +3,9 @@ title: Adhésion
 permalink: /adhesion
 ---
 
+Si vous partagez <a href="/bureau/2018">nos valeurs</a> et que vous souhaitez soutenir nos efforts, rejoignez l'association !
+
+La cotisation annuelle coûte 20 €. En adhérant, vous obtenez accès à nos outils de prise de décision collective et donnez du poids aux initiatives soutenues.
+
 <iframe id="iframe" src="https://agile-france.assoconnect.com/billetterie/offre/128031-n-campagne-adhesion-2020?iframe=1" style="overflow: hidden; border: 0; max-height: none; width: 100%;"></iframe>
 <script>window.addEventListener("message", function(event) {if(event.data.action === "iframe.height" && event.origin === "https://agile-france.assoconnect.com"){document.getElementById("iframe").height = event.data.height;}});</script>

--- a/_pages/association.md
+++ b/_pages/association.md
@@ -1,0 +1,49 @@
+---
+title: Vie associative
+permalink: /association
+---
+
+## Documents officiels
+
+La vie de l'association est encadrée par ses [statuts](/statuts) et son [réglement intérieur](/reglement).
+
+
+## Assemblées générales
+
+Les assemblées générales sont les réunions annuelles lors desquelles le bureau présente son bilan, où le bureau peut être renouvelé, et où de grandes orientations peuvent être décidées.
+
+{% assign assemblees_generales = site.assemblee_generale | reverse %}
+
+{% for ag in assemblees_generales -%}
+- [{{ ag.title }}]({{ ag.url }})
+{% endfor %}
+
+
+## Bureaux
+
+Le bureau de l’association est actuellement composé de :
+
+- [Matti Schneider](https://mattischneider.fr/)
+- Julien Porot
+- [Julie Quillé](https://www.linkedin.com/in/juliequille/)
+- [Christophe Robillard](https://twitter.com/krichtof)
+- Bénédicte Taillebois
+
+Les bureaux successifs ont donné des orientations à l’association qui ont construit son histoire.
+
+{% assign bureaux = site.bureau | reverse %}
+
+{% for bureau in bureaux -%}
+- {{ bureau.election | date: "%Y" }} — [{{ bureau.title }}]({{ bureau.url }})
+{% endfor %}
+
+
+## Le mot de l’asso
+
+Lors de la conférence AgileFrance a régulièrement eu lieu une prise de parole de l’association. Ces « mots » font partie de son histoire publique.
+
+{% assign mots = site.mot_conference | reverse %}
+
+{% for mot in mots -%}
+- [{{ mot.title }}]({{ mot.url }})
+{% endfor %}

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -12,10 +12,6 @@ permalink: /
 
 — _Article 2 des [Statuts de l’association](/statuts)_
 
-## Appel à projets COVID-19
-
-Cet [appel vise à produire du contenu et des outils qui facilitent l'adaptation au confinement](appel-a-projets-covid-19) et est doté de 10 000 € TTC.
-
 ## Notre mode d’action
 
 Notre mode de soutien principal consiste en :
@@ -39,13 +35,6 @@ En contrepartie, nous nous attendons à ce que :
 Cela vous intéresse ? [Proposez votre initiative](mailto:bureau@agile-france.org?subject=Soutien) !
 
 Vous n’êtes pas certain‧e d’être éligible mais votre initiative est compatible avec nos [statuts](/statuts) et vous vous sentez aligné‧e avec les [intentions du bureau](/bureau/2018) ? [Discutons-en](mailto:bureau@agile-france.org?subject=Demande) ! 😉
-
-
-## Adhérer
-
-Si vous partagez [nos valeurs](/bureau/2018) et que vous souhaitez soutenir nos efforts, [rejoignez l'association](adhesion) !
-
-La cotisation annuelle coûte 20 €. En adhérant, vous obtenez accès à nos outils de prise de décision collective et donnez du poids aux initiatives soutenues.
 
 
 ## Initiatives soutenues
@@ -94,50 +83,3 @@ La cotisation annuelle coûte 20 €. En adhérant, vous obtenez accès à nos 
 - Geek Camp
 - Agile Beirut
 - Lean Camp
-
-
-## Le mot de l’asso
-
-Lors de la conférence AgileFrance a régulièrement eu lieu une prise de parole de l’association. Ces « mots » font partie de son histoire publique.
-
-{% assign mots = site.mot_conference | reverse %}
-
-{% for mot in mots -%}
-- [{{ mot.title }}]({{ mot.url }})
-{% endfor %}
-
-
-## Assemblées générales
-
-Les assemblées générales sont les réunions annuelles lors desquelles le bureau présente son bilan, où le bureau peut être renouvelé, et où de grandes orientations peuvent être décidées.
-
-{% assign assemblees_generales = site.assemblee_generale | reverse %}
-
-{% for ag in assemblees_generales -%}
-- [{{ ag.title }}]({{ ag.url }})
-{% endfor %}
-
-
-## Bureaux
-
-Le bureau de l’association est actuellement composé de :
-
-- [Matti Schneider](https://mattischneider.fr/)
-- Julien Porot
-- [Julie Quillé](https://www.linkedin.com/in/juliequille/)
-- [Christophe Robillard](https://twitter.com/krichtof)
-- Bénédicte Taillebois
-
-Les bureaux successifs ont donné des orientations à l’association qui ont construit son histoire.
-
-{% assign bureaux = site.bureau | reverse %}
-
-{% for bureau in bureaux -%}
-- {{ bureau.election | date: "%Y" }} — [{{ bureau.title }}]({{ bureau.url }})
-{% endfor %}
-
-
-## Documents
-
-- [Statuts](/statuts)
-- [Réglement intérieur](/reglement)


### PR DESCRIPTION
- Réunit tous les éléments Documents officiels, AGs, Bureaux, Mots de l'asso dans une seule page « vie associative » qui intéressera surtout les adhérent‧e‧s et adhérent‧e‧s potentielles.
- Laisse sur la page d'accueil le mode d'action et les initiatives soutenues.
- Déplace la suggestion d'adhésion dans la page adhésion elle-même maintenant qu'un lien « Adhérer » est mis en avant dans le menu (#45).
- Simplifie le menu d'autant.

![Capture d’écran 2020-07-26 à 17 01 14](https://user-images.githubusercontent.com/222463/88482469-a7126780-cf61-11ea-8cd6-acc85f81982f.png)
![Capture d’écran 2020-07-26 à 17 01 20](https://user-images.githubusercontent.com/222463/88482474-aa0d5800-cf61-11ea-91d9-4570262f27fe.png)
